### PR TITLE
fix: drain discarded response bodies on fetchRetry retry paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@octocloud/core",
-  "version": "1.0.95",
+  "version": "1.0.96",
   "license": "ISC",
   "author": "",
   "repository": {

--- a/src/util/__tests__/fetchRetry.test.ts
+++ b/src/util/__tests__/fetchRetry.test.ts
@@ -326,4 +326,42 @@ describe('fetchRetry', () => {
       error = unknownError;
     });
   });
+
+  describe('connection management', () => {
+    // Build a response whose body is a stream that never resolves on its own —
+    // it can only complete by being read to the end or cancelled. The `cancel`
+    // spy stands in for undici returning the socket to the pool.
+    const makeStreamingResponse = (status: number): { response: Response; cancel: ReturnType<typeof vi.fn> } => {
+      const cancel = vi.fn();
+      const stream = new ReadableStream({
+        pull() {
+          // Intentionally never enqueue/close: the body stays "open" until the
+          // caller either fully reads it or cancels it.
+        },
+        cancel,
+      });
+      return { response: new Response(stream, { status }), cancel };
+    };
+
+    it('cancels the body of every discarded response so the connection is released', async () => {
+      const first = makeStreamingResponse(503);
+      const second = makeStreamingResponse(503);
+      globalFetchResponse.push(first.response);
+      globalFetchResponse.push(second.response);
+      globalFetchResponse.push(new Response('{}', { status: 200 }));
+
+      response = await fetchRetry(request, {
+        retryDelayMultiplierInMs: RETRY_DELAY_MULTIPLIER_IN_MS,
+        // A predicate that inspects nothing and never consumes the body — the
+        // realistic case that used to leak the connection on every retry.
+        shouldForceRetry: async (): Promise<ShouldForceRetryResult> => ({ forceRetry: false, retryAfter: 0 }),
+      });
+
+      expect(response.status).toBe(200);
+      // Both retried-away responses must have had their underlying source
+      // cancelled (all tee branches released), not left dangling.
+      expect(first.cancel).toHaveBeenCalledTimes(1);
+      expect(second.cancel).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/util/fetchRetry.ts
+++ b/src/util/fetchRetry.ts
@@ -44,6 +44,43 @@ export interface ShouldForceRetryResult {
   retryAfter: number;
 }
 
+/**
+ * Cancel a response body we are not going to hand back to the caller.
+ *
+ * Under undici (Node's global fetch) the socket backing a response stays
+ * checked out of the connection pool until the body is fully consumed or
+ * cancelled. Any response we discard on a retry — or the throwaway clone we
+ * pass to `shouldForceRetry` — must therefore be released explicitly, otherwise
+ * the connection leaks until GC finalizers eventually run and, under load, the
+ * pool is exhausted.
+ */
+async function releaseResponseBody(response: Response | undefined): Promise<void> {
+  if (response === undefined || response.body === null || response.bodyUsed) {
+    return;
+  }
+
+  try {
+    await response.body.cancel();
+  } catch {
+    // The body may already be locked/partially consumed by a caller-supplied
+    // predicate — nothing more we can do, and it is not fatal.
+  }
+}
+
+/**
+ * Discard a response we are retrying past, together with the throwaway clone we
+ * handed to `shouldForceRetry`.
+ *
+ * `res.clone()` tees the underlying stream, and undici only returns the socket
+ * to the pool once *every* tee branch is consumed or cancelled. Cancelling the
+ * branches one after another deadlocks — awaiting `.cancel()` on one branch does
+ * not settle until the sibling branch is also released — so both branches must
+ * be cancelled concurrently.
+ */
+async function discardRetriedResponse(res: Response, inspectionResponse: Response): Promise<void> {
+  await Promise.all([releaseResponseBody(res), releaseResponseBody(inspectionResponse)]);
+}
+
 export async function fetchRetry(
   request: Request,
   defaultOptions: FetchRetryOptions = FETCH_RETRY_DEFAULT_OPTIONS,
@@ -122,9 +159,14 @@ export async function fetchRetry(
 
   options.currentRetryAttempt++;
 
-  const shouldForceRetryResult = await options.shouldForceRetry(res.clone());
-
   if (options.currentRetryAttempt < options.maxRetryAttempts) {
+    // The predicate only matters when a retry is still on the table, so it runs
+    // here rather than unconditionally (on the terminal attempt it would just
+    // buffer the body of the response we are about to return). It gets a
+    // throwaway clone so it can inspect the body without consuming `res`.
+    const inspectionResponse = res.clone();
+    const shouldForceRetryResult = await options.shouldForceRetry(inspectionResponse);
+
     if (shouldForceRetryResult.forceRetry) {
       const retryAfter = shouldForceRetryResult.retryAfter;
 
@@ -132,6 +174,8 @@ export async function fetchRetry(
         options.retryAfter = retryAfter;
       }
 
+      // Release the connections tied to the response we are discarding.
+      await discardRetriedResponse(res, inspectionResponse);
       return await fetchRetry(request, options);
     }
 
@@ -147,9 +191,17 @@ export async function fetchRetry(
       }
 
       if (options.retryAfter <= options.currentRetryAttempt) {
+        // Release the connections tied to the response we are discarding.
+        await discardRetriedResponse(res, inspectionResponse);
         return await fetchRetry(request, options);
       }
     }
+
+    // We are keeping `res` and handing it back to the caller. The inspection
+    // clone must still be released so its tee branch does not pin the
+    // connection, but we must not await it: its cancellation only settles once
+    // the caller consumes `res`, which happens after this function returns.
+    void releaseResponseBody(inspectionResponse);
 
     // Retry is not needed anymore, so we can consume the request object
     if (request.method !== 'GET' && request.method !== 'HEAD' && request.bodyUsed === false) {


### PR DESCRIPTION
## What

Fixes a connection leak on the `fetchRetry` retry paths.

## Why

Every retry branch (`forceRetry` and retry-on-status) threw away the upstream `res` without consuming or cancelling its body. Under undici the socket stays checked out of the pool until the body is drained, so each retry leaked a connection. The only thing draining it was an accidental `await response.text()` side effect inside the default `shouldForceRetry` — which breaks the moment a caller passes a custom predicate that doesn't read the body.

## Changes

- Release the discarded response explicitly before each recursive retry, independent of `shouldForceRetry`.
- Move `shouldForceRetry` inside the `currentRetryAttempt < maxRetryAttempts` block so it no longer buffers the body of the response we're about to return on the terminal attempt.
- Cancel the retried-away response and its inspection clone **concurrently** — `res.clone()` tees the stream, and awaiting `.cancel()` on one branch deadlocks until the sibling branch is released.

## Scope

Connection leaks only. Broader review confirmed the sole genuine connection leak was here; the `clone()` calls in the context classes are memory buffering (out of scope), not connection leaks, under normal response consumption.

## Test

Added a test proving every discarded response's body is cancelled even with a custom `shouldForceRetry` that never reads the body. All 88 tests + typecheck + lint pass.